### PR TITLE
Improve README, add whitespace to match original, fix some broken characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@ DUET algorithm
 ==============
 
 MATLAB code that implements the DUET blind source separation algorithm.
-Code is literally copy pasted from [this publication](http://link.springer.com/chapter/10.1007%2F978-1-4020-6479-1_8#page-1) and [this website](https://web.archive.org/web/20100329094309/http://eleceng.ucd.ie/~srickard/bss.html)
 
+Code is adapted from the Appendix of this publication:
 
-Course webpage [http://www.cs.northwestern.edu/~pardo/courses/casa/papers.php](https://web.archive.org/web/20180521125513/http://www.cs.northwestern.edu/~pardo/courses/casa/papers.php)
+- Rickard, S. (2007). [The DUET Blind Source Separation Algorithm](https://web.archive.org/web/20170513041921/http://www.cs.northwestern.edu/~pardo/courses/casa/papers/DuetSourceSeparationTutorial). In S. Makino, H. Sawada & T.-W. Lee (Eds.), *Blind Speech Separation* (pp. 217-241). Springer. https://doi.org/10.1007/978-1-4020-6479-1_8 (ISBN 978-1-4020-6478-4)
+
+Course webpages:
+
+- [EECS 495-022 Computational Auditory Scene Analysis](https://web.archive.org/web/20180521125513/http://www.cs.northwestern.edu/~pardo/courses/casa/papers.php)
+- [University College Dublin](https://web.archive.org/web/20100329094309/http://eleceng.ucd.ie/~srickard/bss.html) (older [Princeton](https://web.archive.org/web/20050212232452/http://www.princeton.edu:80/~srickard/bss.html) version)
 
 Use `run_duet.m` to run the algorithm.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 DUET algorithm
 ==============
 
-MATLAB code that implements the DUET blind source separation algorithm.
+MATLAB code that implements the DUET (Degenerate Unmixing Estimation Technique) blind source separation algorithm.
 
 Code is adapted from the Appendix of this publication:
 
@@ -11,5 +11,15 @@ Course webpages:
 
 - [EECS 495-022 Computational Auditory Scene Analysis](https://web.archive.org/web/20180521125513/http://www.cs.northwestern.edu/~pardo/courses/casa/papers.php)
 - [University College Dublin](https://web.archive.org/web/20100329094309/http://eleceng.ucd.ie/~srickard/bss.html) (older [Princeton](https://web.archive.org/web/20050212232452/http://www.princeton.edu:80/~srickard/bss.html) version)
+
+The 5-source mixtures audio example files in the [./data](./data/) folder are taken from the above webpages.  They are not the same files or mixing parameters as in the 2007 paper.
+
+There are several variations of DUET.  This version:
+
+- Requires closely-spaced microphones.  It does not include the "Big Delay DUET" methods mentioned in the paper.
+- Does not have automatic peak detection. Needs manual identification of peaks in the histogram and number of sources to demix.
+- Allows for varying *p* and *q* to emphasize different source characteristics in the histogram. Higher *p* emphasizes time-frequency bins where both signals are strong.  Higher *q* emphasizes higher frequencies.  See p. 225.
+- Uses binary masks on the time-frequency points.  T-F points are assigned entirely to only one source. See p. 227 eq. 8.33.
+- Uses theoretically optimal weighting of both microphones during reconstruction, instead of masking only one mixture. See p. 227 eq. 8.34.
 
 Use `run_duet.m` to run the algorithm.

--- a/run_duet.m
+++ b/run_duet.m
@@ -4,122 +4,121 @@ close all
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %    setp 1,2,3
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%1. analyze the signals - STFT
-%1) Create the spectrogram of the Left and Right channels.
-wlen=1024;
-timestep=512;
-numfreq=1024;
-awin=hamming(wlen);%analysis window is a Hamming window Looks like Sine on [0,pi]
+% 1. analyze the signals - STFT
+% 1) Create the spectrogram of the Left and Right channels.
+wlen = 1024;
+timestep = 512;
+numfreq = 1024;
+awin = hamming(wlen); % analysis window is a Hamming window Looks like Sine on [0,pi]
+
 [x1,fs,nbits] = wavread('data/x1_reverb.wav');
 x2 = wavread('data/x2_reverb.wav');
-tf1=tfanalysis(x1,awin,timestep,numfreq);%time-freq domain
-tf2=tfanalysis(x2,awin,timestep,numfreq);%time-freq domain
+
+tf1 = tfanalysis(x1,awin,timestep,numfreq); % time-freq domain
+tf2 = tfanalysis(x2,awin,timestep,numfreq); % time-freq domain
 
 tf1(1,:)=[];
-tf2(1,:)=[];%remove dc component from mixtures
-%eps is the a small constant to avoid dividing by zero frequency in the delay estimation
+tf2(1,:)=[]; % remove dc component from mixtures
+% eps is the a small constant to avoid dividing by zero frequency in the delay estimation
 
-%calculate pos/neg frequencies for later use in delay calc ??
-freq=[(1:numfreq/2) ((-numfreq/2)+1:-1)]*(2*pi/(numfreq)); % freq looks like saw signal
-fmat=freq(ones(size(tf1,2),1),:)';
+% calculate pos/neg frequencies for later use in delay calc ??
+freq = [(1:numfreq/2) ((-numfreq/2)+1:-1)]*(2*pi/(numfreq)); % freq looks like saw signal
+fmat = freq(ones(size(tf1,2),1),:)';
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-%2.calculate alpha and delta for each t-f point
+% 2. calculate alpha and delta for each t-f point
 %2) For each time/frequency compare the phase and amplitude of the left and
-%   right channels. This gives two new coordinates, instead of time-frequency 
+%   right channels. This gives two new coordinates, instead of time-frequency
 %   it is phase-amplitude differences.
-R21=(tf2+eps)./(tf1+eps);%time-freqratioofthemixtures
+R21 = (tf2+eps)./(tf1+eps); % time-freq ratio of the mixtures
 
-%%%2.1HERE WE ESTIMATE THE RELATIVE ATTENUATION (alpha)%%%
-a=abs(R21);%relative attenuation between the two mixtures
-alpha=a-1./a;%'alpha' (symmetric attenuation)
-%%%2.2HERE WE ESTIMATE THE RELATIVE DELAY (delta)%%%%
-delta=-imag(log(R21))./fmat;% imaginary part, 'delta' relative delay
+%%% 2.1 HERE WE ESTIMATE THE RELATIVE ATTENUATION (alpha) %%%
+a = abs(R21); % relative attenuation between the two mixtures
+alpha = a - 1./a; % 'alpha' (symmetric attenuation)
+
+%%% 2.2 HERE WE ESTIMATE THE RELATIVE DELAY (delta) %%%%
+delta = -imag(log(R21))./fmat; % imaginary part, 'delta' relative delay
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-%3.calculate weighted histogram
-%3) Build a 2-d histogram (one dimension is phase, one is amplitude) where 
+% 3. calculate weighted histogram
+% 3) Build a 2-d histogram (one dimension is phase, one is amplitude) where
 %   the height at any phase/amplitude is the count of time-frequency bins that
 %   have approximately that phase/amplitude.
-p=1; q=0; %powers used to weight histogram
-tfweight=(abs(tf1).*abs(tf2)).^p.*abs(fmat).^q; %weights vector
-maxa=0.7;
-maxd=3.6;%histogram boundaries for alpha, delta
+p = 1; q = 0; % powers used to weight histogram
+tfweight = (abs(tf1).*abs(tf2)).^p.*abs(fmat).^q; % weights vector
+maxa = 0.7;
+maxd = 3.6; % histogram boundaries for alpha, delta
 
-abins=35;
-dbins=50;%number of hist bins for alpha, delta
+abins = 35;
+dbins = 50; % number of hist bins for alpha, delta
 
-%only consider time-freq points yielding estimates in bounds
+% only consider time-freq points yielding estimates in bounds
 amask=(abs(alpha)<maxa)&(abs(delta)<maxd);
-alphavec=alpha(amask);
-deltavec=delta(amask);
-tfweight=tfweight(amask);
+alphavec = alpha(amask);
+deltavec = delta(amask);
+tfweight = tfweight(amask);
 
-%determine histogram indices (sampled indices?)
-alphaind=round(1+(abins-1)*(alphavec+maxa)/(2*maxa));
-deltaind=round(1+(dbins-1)*(deltavec+maxd)/(2*maxd));
+% determine histogram indices sampled indices?
+alphaind = round(1+(abins-1)*(alphavec+maxa)/(2*maxa));
+deltaind = round(1+(dbins-1)*(deltavec+maxd)/(2*maxd));
 
-%FULL-SPARSE TRICK TO CREATE 2D WEIGHTED HISTOGRAM
-%A(alphaind(k),deltaind(k)) = tfweight(k), S is abins-by-dbins
-A=full(sparse(alphaind,deltaind,tfweight,abins,dbins));
-%smooththehistogram-localaverage3-by-3neighboringbins
-A=twoDsmooth(A,3);
-
-%plot2-Dhistogram
+% FULL-SPARSE TRICK TO CREATE 2D WEIGHTED HISTOGRAM
+% A(alphaind(k),deltaind(k)) = tfweight(k), S is abins-by-dbins
+A = full(sparse(alphaind,deltaind,tfweight,abins,dbins));
+% smooth the histogram - local average 3-by-3 neighboring bins
+A = twoDsmooth(A,3);
+% plot 2-D histogram
 mesh(linspace(-maxd,maxd,dbins),linspace(-maxa,maxa,abins),A);
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %    step 4,5,6,7
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%4.peak centers (determined from histogram) THIS IS DONE BY HUMAN.
-%4) Determine how many peaks there are in the histogram.
-%5) Find the location of each peak. 
+% 4. peak centers (determined from histogram)  THIS IS DONE BY HUMAN.
+% 4) Determine how many peaks there are in the histogram.
+% 5) Find the location of each peak.
 
-numsources=5;
+numsources = 5;
 
 % peak estimates provided in source code
-peakdelta=[-2 -2 0 2 2];
-peakalpha=[.19 -.21 0 .19 -.21];
+peakdelta = [-2 -2 0 2 2];
+peakalpha = [.19 -.21 0 .19 -.21];
 
 % my own peak estimates. I'm not sure the ones provided are correct.
 peakdelta=[-1.4 .66 1.25 1.9 .51];
 peakalpha=[.4 -.29 .12 .66 -.5];
 
-%convert alpha to a
-peaka=(peakalpha+sqrt(peakalpha.^2+4))/2;
+% convert alpha to a
+peaka = (peakalpha+sqrt(peakalpha.^2+4))/2;
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%5.determine masks for separation
-%6) Assign each time-frequency frame to the nearest peak in phase/amplitude 
+% 5. determine masks for separation
+% 6) Assign each time-frequency frame to the nearest peak in phase/amplitude
 %  space. This partitions the spectrogram into sources (one peak per source)
 
 bestsofar=Inf*ones(size(tf1));
 bestind=zeros(size(tf1));
-for i=1:length(peakalpha)
-    score=abs(peaka(i)*exp(-sqrt(-1)*fmat*peakdelta(i))...
+for i = 1:length(peakalpha)
+    score = abs(peaka(i)*exp(-sqrt(-1)*fmat*peakdelta(i))...
         .*tf1-tf2).^2/(1+peaka(i)^2);
-    mask=(score<bestsofar);
-    bestind(mask)=i;
-    bestsofar(mask)=score(mask);
+    mask = (score < bestsofar);
+    bestind(mask) = i;
+    bestsofar(mask) = score(mask);
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%6.&7.demix with ML alignment and convert to time domain
-%7) Then you create a binary mask (1 for each time-frequency point belonging to my source, 0 for all other points)
-%8) Mask the spectrogram with the mask created in step 7.
-%9) Rebuild the original wave file from 8.
-%10) Listen to the result.
-est=zeros(numsources,length(x1));%demixtures
+% 6. & 7. demix with ML alignment and convert to time domain
+% 7) Then you create a binary mask (1 for each time-frequency point belonging to my source, 0 for all other points)
+% 8) Mask the spectrogram with the mask created in step 7.
+% 9) Rebuild the original wave file from 8.
+% 10) Listen to the result.
+est = zeros(numsources,length(x1)); % demixtures
 for i=1:numsources
-    mask=(bestind==i);
-    esti=tfsynthesis([zeros(1,size(tf1,2));
+    mask = (bestind==i);
+    esti = tfsynthesis([zeros(1,size(tf1,2));
         ((tf1+peaka(i)*exp(sqrt(-1)*fmat*peakdelta(i)).*tf2)...
-            ./(1+peaka(i)^2)).*mask],...
-             sqrt(2)*awin/1024,timestep,numfreq);
-    est(i,:)=esti(1:length(x1))';
-
-    %add back into the demix a little bit of the mixture
-    %as that eliminates most of the masking artifacts
-    soundsc(est(i,:)+0.05*x1',fs);% original code seems to have missed the transpose play demixture
+           ./(1+peaka(i)^2)).*mask],...
+          sqrt(2)*awin/1024, timestep, numfreq);
+    est(i,:) = esti(1:length(x1))';
+    % add back into the demix a little bit of the mixture
+    % as that eliminates most of the masking artifacts
+    soundsc(est(i,:)+0.05*x1',fs); % original code seems to have missed the transpose play demixture
 end

--- a/run_duet.m
+++ b/run_duet.m
@@ -52,17 +52,17 @@ dbins = 50; % number of hist bins for alpha, delta
 
 % only consider time-freq points yielding estimates in bounds
 amask=(abs(alpha)<maxa)&(abs(delta)<maxd);
-alphavec = alpha(amask);
-deltavec = delta(amask);
+alpha_vec = alpha(amask);
+delta_vec = delta(amask);
 tfweight = tfweight(amask);
 
 % determine histogram indices sampled indices?
-alphaind = round(1+(abins-1)*(alphavec+maxa)/(2*maxa));
-deltaind = round(1+(dbins-1)*(deltavec+maxd)/(2*maxd));
+alpha_ind = round(1+(abins-1)*(alpha_vec+maxa)/(2*maxa));
+delta_ind = round(1+(dbins-1)*(delta_vec+maxd)/(2*maxd));
 
 % FULL-SPARSE TRICK TO CREATE 2D WEIGHTED HISTOGRAM
-% A(alphaind(k),deltaind(k)) = tfweight(k), S is abins-by-dbins
-A = full(sparse(alphaind,deltaind,tfweight,abins,dbins));
+% A(alpha_ind(k),delta_ind(k)) = tfweight(k), S is abins-by-dbins
+A = full(sparse(alpha_ind,delta_ind,tfweight,abins,dbins));
 % smooth the histogram - local average 3-by-3 neighboring bins
 A = twoDsmooth(A,3);
 % plot 2-D histogram

--- a/tfanalysis.m
+++ b/tfanalysis.m
@@ -1,28 +1,31 @@
 function tfmat=tfanalysis(x,awin,timestep,numfreq)
-%time-frequency analysis
-%X is the time domain signal
-%AWIN is an analysis window
-%TIMESTEP is the # of samples between adjacent time windows.
-%NUMFREQ is the # of frequency components per time point.
+% time-frequency analysis
+% X is the time domain signal
+% AWIN is an analysis window
+% TIMESTEP is the # of samples between adjacent time windows.
+% NUMFREQ is the # of frequency components per time point.
 %
-%TFMAT complex matrix time-freq representation
-x=x(:); 
-awin=awin(:);%make inputs go column-wise
+% TFMAT complex matrix time-freq representation
+
+x = x(:);
+awin = awin(:); % make inputs go column-wise
+
 nsamp=length(x);
 wlen=length(awin);
-%calc size and init output t-f matrix
-numtime=ceil((nsamp-wlen+1)/timestep);
-tfmat=zeros(numfreq,numtime+1);
+
+% calc size and init output t-f matrix
+numtime = ceil((nsamp-wlen+1)/timestep);
+tfmat = zeros(numfreq,numtime+1);
 
 % so this loop samples x, I though x is already a sample.
-for i=1:numtime
-    sind=((i-1)*timestep)+1; % current start index
-    tfmat(:,i)=fft(x(sind:(sind+wlen-1)).*awin,numfreq);
+for i = 1:numtime
+    sind = ((i-1)*timestep)+1; % current start index
+    tfmat(:,i) = fft(x(sind:(sind+wlen-1)).*awin,numfreq);
 end
 % below is inelegant... but apparently works.
-i=i+1;
-sind=((i-1)*timestep)+1;
-lasts=min(sind,length(x));
-laste=min((sind+wlen-1),length(x));
-tfmat(:,end)=fft([x(lasts:laste);
-                    zeros(wlen-(laste-lasts+1),1)].*awin,numfreq);
+i = i+1;
+sind = ((i-1)*timestep)+1;
+lasts = min(sind,length(x));
+laste = min((sind+wlen-1),length(x));
+tfmat(:,end) = fft([x(lasts:laste);
+               zeros(wlen-(laste-lasts+1),1)].*awin,numfreq);

--- a/tfsynthesis.m
+++ b/tfsynthesis.m
@@ -1,21 +1,22 @@
-function x=tfsynthesis(timefreqmat,swin,timestep,numfreq)
-%time-frequency synthesis
-%TIMEFREQMAT is the complex matrix time-freq representation
-%SWIN is the synthesis window
-%TIMESTEP is the # of samples between adjacent time windows.
-%NUMFREQ is the # of frequency components per time point.
+function x = tfsynthesis(timefreqmat,swin,timestep,numfreq)
+% time-frequency synthesis
+% TIMEFREQMAT is the complex matrix time-freq representation
+% SWIN is the synthesis window
+% TIMESTEP is the # of samples between adjacent time windows.
+% NUMFREQ is the # of frequency components per time point.
 %
-%X contains the reconstructed signal.
+% X contains the reconstructed signal.
 
-swin=swin(:);%make synthesis window go column-wise
-winlen=length(swin);
-[numfreq numtime]=size(timefreqmat);
-ind=rem((1:winlen)-1,numfreq)+1;
-x=zeros((numtime-1)*timestep+winlen,1);
+swin = swin(:); % make synthesis window go column-wise
 
-for i=1:numtime%overlap,window,andadd
-    temp=numfreq*real(ifft(timefreqmat(:,i)));
-    sind=((i-1)*timestep);
-    rind=(sind+1):(sind+winlen);
-    x(rind)=x(rind)+temp(ind).*swin;
+winlen = length(swin);
+[numfreq numtime] = size(timefreqmat);
+ind = rem((1:winlen)-1, numfreq) +1;
+x = zeros((numtime-1)*timestep + winlen,1);
+
+for i = 1:numtime % overlap, window, and add
+    temp = numfreq*real(ifft(timefreqmat(:,i)));
+    sind = ((i-1)*timestep);
+    rind = (sind+1):(sind+winlen);
+    x(rind) = x(rind) + temp(ind).*swin;
 end

--- a/twoDsmooth.m
+++ b/twoDsmooth.m
@@ -1,11 +1,11 @@
 function smat = twoDsmooth(mat,ker)
-%TWO2SMOOTH ? Smooth 2D matrix.
+%TWO2SMOOTH - Smooth 2D matrix.
 %
 % smat = twoDsmooth(mat,ker)
 %
 % MAT is the 2D matrix to be smoothed.
 % KER is either
-%  (1) a scalar, in which case a ker?by?ker matrix of 1/ker?2 is used
+%  (1) a scalar, in which case a ker-by-ker matrix of 1/ker^2 is used
 %      as the matrix averaging kernel
 %  (2) a matrix which is used as the averaging kernel.
 %

--- a/twoDsmooth.m
+++ b/twoDsmooth.m
@@ -1,37 +1,39 @@
-function smat=twoDsmooth(mat,ker)
-%TWO2SMOOTH?Smooth 2D matrix.
+function smat = twoDsmooth(mat,ker)
+%TWO2SMOOTH ? Smooth 2D matrix.
 %
-%smat=twoDsmooth(mat,ker)
+% smat = twoDsmooth(mat,ker)
 %
-%MAT is the 2D matrix to be smoothed.
-%KER is either
-%(1)a scalar,in which case a ker?by?ker matrix of 1/ker?2 is used 
-%   as the matrix averaging kernel
-%(2)a matrix which is used as the averaging kernel.
+% MAT is the 2D matrix to be smoothed.
+% KER is either
+%  (1) a scalar, in which case a ker?by?ker matrix of 1/ker?2 is used
+%      as the matrix averaging kernel
+%  (2) a matrix which is used as the averaging kernel.
 %
-%SMATisthesmoothedmatrix(samesizeasmat).
-if numel(ker)==1,%prod(size(ker))==1 if ker is a scalar
-    kmat=ones(ker,ker)/ker^2;
+% SMAT is the smoothed matrix (same size as mat).
+
+if numel(ker)==1, % prod(size(ker))==1 if ker is a scalar
+    kmat = ones(ker,ker)/ker^2;
 else
-    kmat=ker;
+    kmat = ker;
 end
-%make kmat have odd dimensions
-[kr kc]=size(kmat); 
-if rem(kr,2)==0, %Remainder after division
-    kmat=conv2(kmat,ones(2,1))/2;
-    kr=kr+1;
+
+% make kmat have odd dimensions
+[kr kc] = size(kmat);
+if rem(kr,2) == 0, % Remainder after division
+    kmat = conv2(kmat,ones(2,1))/2;
+    kr = kr + 1;
 end
-if rem(kc,2)==0,
+if rem(kc,2) == 0,
     kmat=conv2(kmat,ones(1,2))/2;
     kc=kc+1;
 end
-[mr mc]=size(mat);
-fkr=floor(kr/2);%number of rows to copy on top and bottom
-fkc=floor(kc/2);%number of columns to copy on either side
-smat=conv2(...
-    [mat(1,1)*ones(fkr,fkc) ones(fkr,1)*mat(1,:)...
+[mr mc] = size(mat);
+fkr = floor(kr/2); % number of rows to copy on top and bottom
+fkc = floor(kc/2); % number of columns to copy on either side
+smat = conv2(...
+    [mat(1,1)*ones(fkr,fkc) ones(fkr,1)*mat(1,:) ...
     mat(1,mc)*ones(fkr,fkc);
     mat(:,1)*ones(1,fkc) mat mat(:,mc)*ones(1,fkc)
-    mat(mr,1)*ones(fkr,fkc) ones(fkr,1)*mat(mr,:)...
+    mat(mr,1)*ones(fkr,fkc) ones(fkr,1)*mat(mr,:) ...
     mat(mr,mc)*ones(fkr,fkc)],...
     rot90(kmat,2),'valid'); %flipud(fliplr(kmat)) replaced by rot90(kmat,2)


### PR DESCRIPTION
## Improve README citation

- Include more details about original paper, and a link to a downloadable PDF.
- Move "this website" under course information.
- Clarify what CASA and DUET stand for.
- The files have been modified somewhat from the original, not a literal copy.
- Clarify audio files source and DUET variant

## Fix whitespace in .m files

Added spaces and newlines to match the appearance in DuetSourceSeparationTutorial.pdf more accurately.  The lack of spacing had caused some words to be mashed together.

## Fix special characters in .m files

The PDF formatting converted hyphens to minus signs, carets to circumflex accents, asterisks to asterisk operators, and underscores to blanks, which resulted in some mangled text and variable name differences.

